### PR TITLE
update helloworld image version to match the quickstart guide

### DIFF
--- a/kubernetes/canary/deployment.yaml
+++ b/kubernetes/canary/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: helloworld
-        image: gcr.io/pipecd/helloworld:v0.5.0
+        image: gcr.io/pipecd/helloworld:v0.1.0
         args:
           - server
         ports:


### PR DESCRIPTION
Fixes pipe-cd/pipe#1149

> According to QuickStart, the version of the helloworld image in kubernetes/canary/deployment.yaml L22 is v0.1.0, but in fact, v0.5.0 is correct.

fix it :)