### PR TITLE
Fix: Sync examples from v0/ and v1/ after repo restructure

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -18,14 +18,9 @@ jobs:
       - run: |
           git -C pipecd rev-parse HEAD > examples/HEAD.txt
           cd examples
-          rm -rf cloudrun deployment-chain ecs kubernetes lambda local-modules terraform
-          cp -rf ../pipecd/examples/cloudrun .
-          cp -rf ../pipecd/examples/deployment-chain .
-          cp -rf ../pipecd/examples/ecs .
-          cp -rf ../pipecd/examples/kubernetes .
-          cp -rf ../pipecd/examples/lambda .
-          cp -rf ../pipecd/examples/local-modules .
-          cp -rf ../pipecd/examples/terraform .
+          rm -rf cloudrun deployment-chain ecs kubernetes lambda local-modules terraform v0 v1
+          cp -rf ../pipecd/examples/v0 .
+          cp -rf ../pipecd/examples/v1 .
           cp -rf ../pipecd/examples/README.remote.md README.md
           if [[ -z `git status --porcelain` ]]; then
             exit


### PR DESCRIPTION
### What this does

After pipe-cd/pipecd#7173 split the examples into v0/ and v1/, this sync workflow was still copying the old top-level directories (`cloudrun`, `kubernetes`, `ecs`, ...) which no longer exist at that path. So the hourly cron would fail.

This updates the sync to copy examples/v0 and examples/v1 from the main repo instead.

### Notes

- it also adds kubernetes_multicluster, which the old explicit list wasn't copying.
- README.remote.md -> `README.md` behaviour is unchanged.
- Once this is merged and runs, I'll follow up separately to update the docs-dev/examples/_index.md links to point at the new v0/ paths (ref pipe-cd/pipecd#6266).

cc @khanhtc1202